### PR TITLE
Prevents Airlocks from squishing people out of stasis- and bodybags

### DIFF
--- a/code/game/machinery/doors/airlock_interactions.dm
+++ b/code/game/machinery/doors/airlock_interactions.dm
@@ -24,6 +24,12 @@
 
 /mob/living/blocks_airlock()
 	return 1
+	
+/obj/structure/closet/body_bag/blocks_airlock() //These two lines prevent Airlocks from closing on Body- and stasisbags, thus ejecting the occupant
+	return 1
+
+/obj/structure/closet/body_bag/cryobag/blocks_airlock()
+	return 1
 
 //*** Airlock Crushing
 

--- a/code/game/machinery/doors/airlock_interactions.dm
+++ b/code/game/machinery/doors/airlock_interactions.dm
@@ -29,13 +29,8 @@
 	if (locate(/mob) in src)
 		return 1
 	else
-		return 0				//Prevents Airlocks from closing on Bodybags with people inside
+		return 0				//Prevents Airlocks from closing on Bodybags and Cryobags with people inside
 	
-/obj/structure/closet/body_bag/cryobag/blocks_airlock()
-	if (locate(/mob) in src)
-		return 1
-	else
-		return 0				//Same for Cryobags
 
 //*** Airlock Crushing
 

--- a/code/game/machinery/doors/airlock_interactions.dm
+++ b/code/game/machinery/doors/airlock_interactions.dm
@@ -25,11 +25,17 @@
 /mob/living/blocks_airlock()
 	return 1
 	
-/obj/structure/closet/body_bag/blocks_airlock() //These two lines prevent Airlocks from closing on Body- and stasisbags, thus ejecting the occupant
-	return 1
-
+/obj/structure/closet/body_bag/blocks_airlock()
+	if (locate(/mob) in src)
+		return 1
+	else
+		return 0				//Prevents Airlocks from closing on Bodybags with people inside
+	
 /obj/structure/closet/body_bag/cryobag/blocks_airlock()
-	return 1
+	if (locate(/mob) in src)
+		return 1
+	else
+		return 0				//Same for Cryobags
 
 //*** Airlock Crushing
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You find a README and example file in .\html\changelogs\ for further instructions.
-->

Adds a few lines to airlock_interactions.dm to prevent airlocks from closing when their turf is occupied by a stasis- or bodybag. This is to fix Issue #14577